### PR TITLE
Update interface for safe-string

### DIFF
--- a/lib/fd_send_recv.ml
+++ b/lib/fd_send_recv.ml
@@ -19,6 +19,9 @@ let _ = Callback.register_exception "fd_send_recv.unix_error" (Unix_error (0))
 external send_fd : Unix.file_descr -> bytes -> int -> int -> Unix.msg_flag list -> Unix.file_descr -> int = "stub_unix_send_fd_bytecode" "stub_unix_send_fd"
 external recv_fd : Unix.file_descr -> bytes -> int -> int -> Unix.msg_flag list -> int * Unix.sockaddr * Unix.file_descr = "stub_unix_recv_fd"
 
+let send_fd_substring channel_fd buf ofs len flags fd_to_send =
+    send_fd channel_fd (Bytes.unsafe_of_string buf) ofs len flags fd_to_send
+
 let fd_of_int (x: int) : Unix.file_descr = Obj.magic x
 
 let int_of_fd (x: Unix.file_descr) : int = Obj.magic x

--- a/lib/fd_send_recv.ml
+++ b/lib/fd_send_recv.ml
@@ -16,8 +16,8 @@ exception Unix_error of int
 
 let _ = Callback.register_exception "fd_send_recv.unix_error" (Unix_error (0))
 
-external send_fd : Unix.file_descr -> string -> int -> int -> Unix.msg_flag list -> Unix.file_descr -> int = "stub_unix_send_fd_bytecode" "stub_unix_send_fd"
-external recv_fd : Unix.file_descr -> string -> int -> int -> Unix.msg_flag list -> int * Unix.sockaddr * Unix.file_descr = "stub_unix_recv_fd"
+external send_fd : Unix.file_descr -> bytes -> int -> int -> Unix.msg_flag list -> Unix.file_descr -> int = "stub_unix_send_fd_bytecode" "stub_unix_send_fd"
+external recv_fd : Unix.file_descr -> bytes -> int -> int -> Unix.msg_flag list -> int * Unix.sockaddr * Unix.file_descr = "stub_unix_recv_fd"
 
 let fd_of_int (x: int) : Unix.file_descr = Obj.magic x
 

--- a/lib/fd_send_recv.mli
+++ b/lib/fd_send_recv.mli
@@ -32,6 +32,10 @@ val recv_fd : Unix.file_descr -> bytes -> int -> int ->
     substring [buf] [ofs] [len] with [flags], returning the number of
     bytes read, the address of the peer and a file descriptor. *)
 
+val send_fd_substring : Unix.file_descr -> string -> int -> int ->
+  Unix.msg_flag list -> Unix.file_descr -> int
+(** Like [send_fd] but takes a string *)
+
 val int_of_fd : Unix.file_descr -> int
 (** [int_of_fd fd] returns the underlying unix integer file descriptor
     associated with OCaml Unix.file_descr [fd]. *)

--- a/lib/fd_send_recv.mli
+++ b/lib/fd_send_recv.mli
@@ -17,7 +17,7 @@
 exception Unix_error of int
 (** Thrown by the low-level C functions *)
 
-val send_fd : Unix.file_descr -> string -> int -> int ->
+val send_fd : Unix.file_descr -> bytes -> int -> int ->
   Unix.msg_flag list -> Unix.file_descr -> int
 (** [send_fd channel_fd buf ofs len flags fd_to_send] sends a message
 	  over [channel_fd] containing the [buf] [ofs] [len] substring, with
@@ -26,7 +26,7 @@ val send_fd : Unix.file_descr -> string -> int -> int ->
 	  (e.g. of size greater than zero) to actually have the fd
 	  passed. *)
 
-val recv_fd : Unix.file_descr -> string -> int -> int ->
+val recv_fd : Unix.file_descr -> bytes -> int -> int ->
   Unix.msg_flag list -> int * Unix.sockaddr * Unix.file_descr
 (** [recv_fd channel_fd buf ofs len flags] receives a message into
     substring [buf] [ofs] [len] with [flags], returning the number of

--- a/test/test.ml
+++ b/test/test.ml
@@ -7,13 +7,13 @@ let t_receivefd fd =
   let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 2 [] in
   Printf.printf "[receiver] Received %d bytes, received fd = %d\n%!" nb_read (int_of_fd fd_recv);
   let message = "[receiver] I'm the receiver, and I'm writing into the fd you passed to me :p\n" in
-  let nb_written = write fd_recv (Bytes.unsafe_of_string message) 0 (String.length message) in
+  let nb_written = write_substring fd_recv message 0 (String.length message) in
   assert (nb_written = String.length message)
 
 let t_sendfd fd =
   let fd_to_send = stdout in
-  let buf = Bytes.of_string "  " in
-  let nb_sent = send_fd fd buf 0 2 [] fd_to_send in
+  let buf = "  " in
+  let nb_sent = send_fd_substring fd buf 0 2 [] fd_to_send in
   Printf.printf "[sender] sent %d bytes, sent fd = %d\n%!" nb_sent (int_of_fd fd_to_send)
 
 let main () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,16 +3,16 @@ open Fd_send_recv
 
 let t_receivefd fd =
   Printf.printf "[receiver] t_receivedfd thread started!\n%!";
-  let buf = "**" in
+  let buf = Bytes.of_string "**" in
   let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 2 [] in
   Printf.printf "[receiver] Received %d bytes, received fd = %d\n%!" nb_read (int_of_fd fd_recv);
   let message = "[receiver] I'm the receiver, and I'm writing into the fd you passed to me :p\n" in
-  let nb_written = write fd_recv message 0 (String.length message) in
+  let nb_written = write fd_recv (Bytes.unsafe_of_string message) 0 (String.length message) in
   assert (nb_written = String.length message)
 
 let t_sendfd fd =
   let fd_to_send = stdout in
-  let buf = "  " in
+  let buf = Bytes.of_string "  " in
   let nb_sent = send_fd fd buf 0 2 [] fd_to_send in
   Printf.printf "[sender] sent %d bytes, sent fd = %d\n%!" nb_sent (int_of_fd fd_to_send)
 

--- a/test/test_fork.ml
+++ b/test/test_fork.ml
@@ -7,13 +7,13 @@ let t_receivefd fd =
   let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 2 [] in
   Printf.printf "[receiver] Received %d bytes, received fd = %d\n%!" nb_read (int_of_fd fd_recv);
   let message = "[receiver] I'm the receiver, and I'm writing into the fd you passed to me :p\n" in
-  let nb_written = write fd_recv (Bytes.unsafe_of_string message) 0 (String.length message) in
+  let nb_written = write_substring fd_recv message 0 (String.length message) in
   assert (nb_written = String.length message)
 
 let t_sendfd fd =
   let fd_to_send = stdout in
-  let buf = Bytes.of_string "  " in
-  let nb_sent = send_fd fd buf 0 2 [] fd_to_send in
+  let buf = "  " in
+  let nb_sent = send_fd_substring fd buf 0 2 [] fd_to_send in
   Printf.printf "[sender] sent %d bytes, sent fd = %d\n%!" nb_sent (int_of_fd fd_to_send)
 
 let main () =

--- a/test/test_fork.ml
+++ b/test/test_fork.ml
@@ -3,16 +3,16 @@ open Fd_send_recv
 
 let t_receivefd fd =
   Printf.printf "[receiver] t_receivedfd thread started!\n%!";
-  let buf = "**" in
+  let buf = Bytes.of_string "**" in
   let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 2 [] in
   Printf.printf "[receiver] Received %d bytes, received fd = %d\n%!" nb_read (int_of_fd fd_recv);
   let message = "[receiver] I'm the receiver, and I'm writing into the fd you passed to me :p\n" in
-  let nb_written = write fd_recv message 0 (String.length message) in
+  let nb_written = write fd_recv (Bytes.unsafe_of_string message) 0 (String.length message) in
   assert (nb_written = String.length message)
 
 let t_sendfd fd =
   let fd_to_send = stdout in
-  let buf = "  " in
+  let buf = Bytes.of_string "  " in
   let nb_sent = send_fd fd buf 0 2 [] fd_to_send in
   Printf.printf "[sender] sent %d bytes, sent fd = %d\n%!" nb_sent (int_of_fd fd_to_send)
 

--- a/test_tuntap/test_tuntap.ml
+++ b/test_tuntap/test_tuntap.ml
@@ -3,14 +3,14 @@ open Fd_send_recv
 
 let t_receivefd fd =
   Printf.printf "[receiver] t_receivedfd thread started!\n%!";
-  let buf = String.make (Tuntap.get_ifnamsiz ()) '\000' in
-  let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 (String.length buf) [] in
+  let buf = Bytes.make (Tuntap.get_ifnamsiz ()) '\000' in
+  let nb_read, remote_saddr, fd_recv = recv_fd fd buf 0 (Bytes.length buf) [] in
   Printf.printf "[receiver] Received %d bytes [%s], received fd = %d\n%!" 
-    nb_read (String.sub buf 0 nb_read) (int_of_fd fd_recv)
+    nb_read (Bytes.sub_string buf 0 nb_read) (int_of_fd fd_recv)
 
 let t_sendfd fd =
   let fd_to_send, iface_name = Tuntap.opentap () in
-  let nb_sent = send_fd fd iface_name 0 (String.length iface_name) [] fd_to_send in
+  let nb_sent = send_fd fd (Bytes.unsafe_of_string iface_name) 0 (String.length iface_name) [] fd_to_send in
   Printf.printf "[sender] sent %d bytes [%s], sent fd = %d\n%!" nb_sent
     (String.sub iface_name 0 nb_sent) (int_of_fd fd_to_send)
 

--- a/test_tuntap/test_tuntap.ml
+++ b/test_tuntap/test_tuntap.ml
@@ -10,7 +10,7 @@ let t_receivefd fd =
 
 let t_sendfd fd =
   let fd_to_send, iface_name = Tuntap.opentap () in
-  let nb_sent = send_fd fd (Bytes.unsafe_of_string iface_name) 0 (String.length iface_name) [] fd_to_send in
+  let nb_sent = send_fd_substring fd iface_name 0 (String.length iface_name) [] fd_to_send in
   Printf.printf "[sender] sent %d bytes [%s], sent fd = %d\n%!" nb_sent
     (String.sub iface_name 0 nb_sent) (int_of_fd fd_to_send)
 


### PR DESCRIPTION
This makes use of bytes if the object has to be mutable and makes interface closer to the `Unix` module