### PR TITLE
fd_send_recv_stubs: fix build with ocaml earlier than 5

### DIFF
--- a/lib/fd_send_recv_stubs.c
+++ b/lib/fd_send_recv_stubs.c
@@ -34,6 +34,11 @@
 #include <caml/callback.h>
 #include <caml/unixsupport.h>
 
+#include <caml/version.h>
+#if OCAML_VERSION_MAJOR < 5
+#define caml_uerror uerror
+#endif
+
 static int msg_flag_table[] = {
   MSG_OOB, MSG_DONTROUTE, MSG_PEEK
 };


### PR DESCRIPTION
`caml_uerror` was introduced in ocaml 5.  Before it was simply called `uerror`.